### PR TITLE
time.Time performance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2014 Philip Hofer
+Portions Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ the data "type" (`int8`) and the raw binary. You [can see a worked example in th
 
 ### Status
 
-Alpha. I _will_ break stuff. There is an open milestone for Beta stability (targeted for January.)
+Alpha. I _will_ break stuff. There is an open milestone for Beta stability (targeted for January.) Only the `/msgp` sub-directory will have a stability guarantee.
 
 You can read more about how `msgp` maps MessagePack types onto Go types [in the wiki](http://github.com/philhofer/msgp/wiki).
 

--- a/_generated/gen_test.go
+++ b/_generated/gen_test.go
@@ -47,13 +47,11 @@ func BenchmarkFastDecode(b *testing.B) {
 
 	var buf bytes.Buffer
 	msgp.Encode(&buf, v)
-	rd := bytes.NewReader(buf.Bytes())
-	dc := msgp.NewReader(rd)
+	dc := msgp.NewReader(msgp.NewEndlessReader(buf.Bytes()))
 	b.SetBytes(int64(buf.Len()))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rd.Seek(0, 0) // reset
 		v.DecodeMsg(dc)
 	}
 }

--- a/gen/elem_enc.tmpl
+++ b/gen/elem_enc.tmpl
@@ -29,7 +29,6 @@
 	if err != nil {
 		return
 	}
-
 	for {{.Keyidx}}, {{.Validx}} := range {{.Varname}} {
 		err = en.WriteString({{.Keyidx}})
 		if err != nil {

--- a/msgp/defs.go
+++ b/msgp/defs.go
@@ -2,8 +2,7 @@
 //
 // This package defines the utilites used by the msgp code generator for encoding and decoding MessagePack
 // from []byte and io.Reader/io.Writer types. Much of this package is devoted to helping the msgp code
-// generator implement the Marshaler/Unmarshaler and Encodable/Decodable interfaces for arbitrary
-// input times.
+// generator implement the Marshaler/Unmarshaler and Encodable/Decodable interfaces.
 //
 // This package defines four "families" of functions:
 // 	- AppendXxxx() appends an object to a []byte in MessagePack encoding.

--- a/msgp/edit.go
+++ b/msgp/edit.go
@@ -185,7 +185,7 @@ func locateKV(raw []byte, key string) (start int, end int) {
 	return 0, 0
 }
 
-// delta is delta on map size; extra is extra space in slice
+// delta is delta on map size
 func resizeMap(raw []byte, delta int64) []byte {
 	var sz int64
 	switch raw[0] {

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -2,6 +2,7 @@ package msgp
 
 import (
 	"fmt"
+	"reflect"
 )
 
 var (
@@ -126,3 +127,16 @@ func (i InvalidPrefixError) Error() string {
 
 // Resumable returns 'false' for InvalidPrefixErrors
 func (i InvalidPrefixError) Resumable() bool { return false }
+
+// ErrUnsupportedType is returned
+// when a bad argument is supplied
+// to a function that takes `interface{}`.
+type ErrUnsupportedType struct {
+	T reflect.Type
+}
+
+// Error implements error
+func (e *ErrUnsupportedType) Error() string { return fmt.Sprintf("msgp: type %q not supported", e.T) }
+
+// Resumable returns 'true' for ErrUnsupportedType
+func (e *ErrUnsupportedType) Resumable() bool { return true }

--- a/msgp/integers.go
+++ b/msgp/integers.go
@@ -139,6 +139,37 @@ func getMuint8(b []byte) (u uint8) {
 	return
 }
 
+func getUnix(b []byte) (sec int64, nsec int32) {
+	sec |= int64(b[0]) << 56
+	sec |= int64(b[1]) << 48
+	sec |= int64(b[2]) << 40
+	sec |= int64(b[3]) << 32
+	sec |= int64(b[4]) << 24
+	sec |= int64(b[5]) << 16
+	sec |= int64(b[6]) << 8
+	sec |= int64(b[7])
+	nsec |= int32(b[8]) << 24
+	nsec |= int32(b[9]) << 16
+	nsec |= int32(b[10]) << 8
+	nsec |= int32(b[11])
+	return
+}
+
+func putUnix(b []byte, sec int64, nsec int32) {
+	b[0] = byte(sec >> 56)
+	b[1] = byte(sec >> 48)
+	b[2] = byte(sec >> 40)
+	b[3] = byte(sec >> 32)
+	b[4] = byte(sec >> 24)
+	b[5] = byte(sec >> 16)
+	b[6] = byte(sec >> 8)
+	b[7] = byte(sec)
+	b[8] = byte(nsec >> 24)
+	b[9] = byte(nsec >> 16)
+	b[10] = byte(nsec >> 8)
+	b[11] = byte(nsec)
+}
+
 /* -----------------------------
 		prefix utilities
    ----------------------------- */

--- a/msgp/read_bytes_test.go
+++ b/msgp/read_bytes_test.go
@@ -435,6 +435,16 @@ func TestReadTimeBytes(t *testing.T) {
 	}
 }
 
+func BenchmarkReadTimeBytes(b *testing.B) {
+	data := AppendTime(nil, time.Now())
+	b.SetBytes(15)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ReadTimeBytes(data)
+	}
+}
+
 func TestReadIntfBytes(t *testing.T) {
 	var buf bytes.Buffer
 	en := NewWriter(&buf)
@@ -452,7 +462,9 @@ func TestReadIntfBytes(t *testing.T) {
 
 	for i, v := range tests {
 		buf.Reset()
-		en.WriteIntf(v)
+		if err := en.WriteIntf(v); err != nil {
+			t.Fatal(err)
+		}
 		en.Flush()
 
 		out, left, err := ReadIntfBytes(buf.Bytes())
@@ -463,7 +475,7 @@ func TestReadIntfBytes(t *testing.T) {
 			t.Errorf("expected 0 bytes left; found %d", len(left))
 		}
 		if !reflect.DeepEqual(v, out) {
-			t.Errorf("%v in; %v out", v, out)
+			t.Errorf("ReadIntf(): %v in; %v out", v, out)
 		}
 	}
 

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -634,8 +634,15 @@ func TestTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// check for equivalence
 	if !now.Equal(out) {
 		t.Fatalf("%s in; %s out", now, out)
+	}
+
+	// check for time.Local zone
+	if now != out {
+		t.Error("returned time.Time not set to time.Local")
 	}
 }
 

--- a/msgp/size.go
+++ b/msgp/size.go
@@ -24,7 +24,7 @@ const (
 	Complex64Size  = 10
 	Complex128Size = 18
 
-	TimeSize = 18
+	TimeSize = 15
 	BoolSize = 1
 	NilSize  = 1
 

--- a/msgp/write_bytes_test.go
+++ b/msgp/write_bytes_test.go
@@ -3,6 +3,7 @@ package msgp
 import (
 	"bytes"
 	"testing"
+	"time"
 )
 
 func TestAppendMapHeader(t *testing.T) {
@@ -274,5 +275,16 @@ func BenchmarkAppendBool(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		AppendBool(buf[0:0], vs[i%2])
+	}
+}
+
+func BenchmarkAppendTime(b *testing.B) {
+	t := time.Now()
+	b.SetBytes(15)
+	buf := make([]byte, 0, 15)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		AppendTime(buf[0:0], t)
 	}
 }

--- a/parse/directives.go
+++ b/parse/directives.go
@@ -7,11 +7,15 @@ import (
 	"strings"
 )
 
+const linePrefix = "//msgp:"
+
+type directive func([]string, *FileSet) error
+
 // map of all recognized directives
 //
 // to add a directive, define a func([]string, *FileSet) error
 // and then add it to this list.
-var directives = map[string]func([]string, *FileSet) error{
+var directives = map[string]directive{
 	"shim":   applyShim,
 	"ignore": ignore,
 	"tuple":  astuple,
@@ -28,8 +32,8 @@ func yieldComments(c []*ast.CommentGroup) []string {
 	var out []string
 	for _, cg := range c {
 		for _, line := range cg.List {
-			if strings.HasPrefix(line.Text, "//msgp:") {
-				out = append(out, strings.TrimPrefix(line.Text, "//msgp:"))
+			if strings.HasPrefix(line.Text, linePrefix) {
+				out = append(out, strings.TrimPrefix(line.Text, linePrefix))
 			}
 		}
 	}
@@ -84,6 +88,7 @@ func ignore(text []string, f *FileSet) error {
 	return nil
 }
 
+//msgp:tuple {TypeA} {TypeB}...
 func astuple(text []string, f *FileSet) error {
 	if len(text) < 2 {
 		return nil

--- a/parse/resolve.go
+++ b/parse/resolve.go
@@ -12,13 +12,13 @@ func (fs *FileSet) findUnresolved(g gen.Elem) []string {
 
 	switch g.Type() {
 	case gen.PtrType:
-		return fs.findUnresolved(g.(*gen.Ptr).Value)
+		return fs.findUnresolved(g.Ptr().Value)
 
 	case gen.SliceType:
-		return fs.findUnresolved(g.(*gen.Slice).Els)
+		return fs.findUnresolved(g.Slice().Els)
 
 	case gen.BaseType:
-		b := g.(*gen.BaseElem)
+		b := g.Base()
 		if b.Value == gen.IDENT { // type is unrecognized
 			id := b.Ident
 			if tp, ok := fs.Identities[id]; ok {
@@ -46,7 +46,7 @@ func (fs *FileSet) findUnresolved(g gen.Elem) []string {
 		return nil
 
 	case gen.StructType:
-		s := g.(*gen.Struct)
+		s := g.Struct()
 
 		out := make([]string, 0, len(s.Fields))
 		nm := s.Name
@@ -64,7 +64,7 @@ func (fs *FileSet) findUnresolved(g gen.Elem) []string {
 		return out
 
 	case gen.MapType:
-		return fs.findUnresolved(g.(*gen.Map).Value)
+		return fs.findUnresolved(g.Map().Value)
 
 	default:
 		return nil


### PR DESCRIPTION
Fixes #39 

The old `time.Time` encoding had to allocate. I tried reproducing the `MarshalBinary` method, but the `Time` type simply doesn't export enough information to replicate the encoding, so I just switched to using straight Unix time.

In the benchmark cases, `(*TestBench).Encode` and `(*TestBench).AppendMsg` both take 33% less time. (And this is for a struct with 6 fields, only one of which was `time.Time`.)