### PR TITLE
Type map

### DIFF
--- a/gen/elem_dec.tmpl
+++ b/gen/elem_dec.tmpl
@@ -92,7 +92,7 @@
 		return
 	}
 	for xplz:=uint32(0); xplz<isz; xplz++ {
-		field, err = dc.ReadMapKey(field)
+		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}

--- a/msgp/elsize.go
+++ b/msgp/elsize.go
@@ -1,0 +1,99 @@
+package msgp
+
+// size of every object on the wire,
+// plus type information. gives us
+// constant-time type information
+// for traversing composite objects.
+//
+var sizes = [256]bytespec{
+	mnil:      {size: 1, extra: constsize, typ: NilType},
+	mfalse:    {size: 1, extra: constsize, typ: BoolType},
+	mtrue:     {size: 1, extra: constsize, typ: BoolType},
+	mbin8:     {size: 2, extra: extra8, typ: BinType},
+	mbin16:    {size: 3, extra: extra16, typ: BinType},
+	mbin32:    {size: 5, extra: extra32, typ: BinType},
+	mext8:     {size: 3, extra: extra8, typ: ExtensionType},
+	mext16:    {size: 4, extra: extra16, typ: ExtensionType},
+	mext32:    {size: 6, extra: extra32, typ: ExtensionType},
+	mfloat32:  {size: 5, extra: constsize, typ: Float32Type},
+	mfloat64:  {size: 9, extra: constsize, typ: Float64Type},
+	muint8:    {size: 2, extra: constsize, typ: UintType},
+	muint16:   {size: 3, extra: constsize, typ: UintType},
+	muint32:   {size: 5, extra: constsize, typ: UintType},
+	muint64:   {size: 9, extra: constsize, typ: UintType},
+	mint8:     {size: 2, extra: constsize, typ: IntType},
+	mint16:    {size: 3, extra: constsize, typ: IntType},
+	mint32:    {size: 5, extra: constsize, typ: IntType},
+	mint64:    {size: 9, extra: constsize, typ: IntType},
+	mfixext1:  {size: 3, extra: constsize, typ: ExtensionType},
+	mfixext2:  {size: 4, extra: constsize, typ: ExtensionType},
+	mfixext4:  {size: 6, extra: constsize, typ: ExtensionType},
+	mfixext8:  {size: 10, extra: constsize, typ: ExtensionType},
+	mfixext16: {size: 18, extra: constsize, typ: ExtensionType},
+	mstr8:     {size: 2, extra: extra8, typ: StrType},
+	mstr16:    {size: 3, extra: extra16, typ: StrType},
+	mstr32:    {size: 5, extra: extra32, typ: StrType},
+	marray16:  {size: 2, extra: array16v, typ: ArrayType},
+	marray32:  {size: 5, extra: array32v, typ: ArrayType},
+	mmap16:    {size: 2, extra: map16v, typ: MapType},
+	mmap32:    {size: 5, extra: map32v, typ: MapType},
+}
+
+func init() {
+	// set up fixed fields
+
+	// fixint
+	for i := mfixint; i < 0x80; i++ {
+		sizes[i] = bytespec{size: 1, extra: constsize, typ: IntType}
+	}
+
+	// nfixint
+	for i := mnfixint; i < 0xff; i++ {
+		sizes[i] = bytespec{size: 1, extra: constsize, typ: IntType}
+	}
+
+	// fixstr gets constsize,
+	// since the prefix yields the size
+	for i := mfixstr; i < 0xc0; i++ {
+		sizes[i] = bytespec{size: 1 + rfixstr(i), extra: constsize, typ: StrType}
+	}
+
+	// fixmap
+	for i := mfixmap; i < 0x90; i++ {
+		sizes[i] = bytespec{size: 1, extra: varmode(2 * rfixmap(i)), typ: MapType}
+	}
+
+	// fixarray
+	for i := mfixarray; i < 0xa0; i++ {
+		sizes[i] = bytespec{size: 1, extra: varmode(rfixarray(i)), typ: ArrayType}
+	}
+}
+
+// a valid bytespsec has
+// non-zero 'size' and
+// non-zero 'typ'
+type bytespec struct {
+	size  uint8   // prefix size information
+	extra varmode // extra size information
+	typ   Type    // type
+	_     byte    // makes bytespec 4 bytes (yes, this matters)
+}
+
+// size mode
+// if positive, # elements for composites
+type varmode int8
+
+const (
+	constsize varmode = 0  // constant size (size bytes + uint8(varmode) objects)
+	extra8            = -1 // has uint8(p[1]) extra bytes
+	extra16           = -2 // has be16(p[1:]) extra bytes
+	extra32           = -3 // has be32(p[1:]) extra bytes
+	map16v            = -4 // use map16
+	map32v            = -5 // use map32
+	array16v          = -6 // use array16
+	array32v          = -7 // use array32
+)
+
+func getType(v byte) Type {
+	return sizes[v].typ
+}

--- a/msgp/errors.go
+++ b/msgp/errors.go
@@ -37,7 +37,7 @@ func (e errShort) Resumable() bool { return true }
 
 type errFatal struct{}
 
-func (f errFatal) Error() string   { return "msgp: fatal decoding error" }
+func (f errFatal) Error() string   { return "msgp: fatal decoding error (unreachable code)" }
 func (f errFatal) Resumable() bool { return false }
 
 // ArrayError is an error returned
@@ -108,7 +108,7 @@ func (t TypeError) Resumable() bool { return true }
 // TypeError depending on whether or not
 // the prefix is recognized
 func badPrefix(want Type, lead byte) error {
-	t := getType(lead)
+	t := sizes[lead].typ
 	if t == InvalidType {
 		return InvalidPrefixError(lead)
 	}

--- a/msgp/integers.go
+++ b/msgp/integers.go
@@ -6,8 +6,8 @@ package msgp
 
 	TODO(philhofer): there are faster,
 	albeit non-portable solutions
-	to the code below. assembler ends
-	up being slow b/c of no inlining
+	to the code below. implement
+	byteswap?
    ---------------------------------- */
 
 func putMint64(b []byte, i int64) {

--- a/msgp/json_bytes_test.go
+++ b/msgp/json_bytes_test.go
@@ -25,7 +25,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	enc.WriteInt64(-100)
 
 	enc.WriteString("an extension")
-	enc.WriteExtension(&RawExtension{1, []byte("blaaahhh")})
+	enc.WriteExtension(&RawExtension{Type: 1, Data: []byte("blaaahhh")})
 
 	enc.WriteString("some bytes")
 	enc.WriteBytes([]byte("here are some bytes"))

--- a/msgp/read_bytes_test.go
+++ b/msgp/read_bytes_test.go
@@ -502,7 +502,7 @@ func BenchmarkSkipBytes(b *testing.B) {
 	en.WriteBool(true)
 
 	en.WriteString("ext")
-	en.WriteExtension(&RawExtension{55, []byte("raw data!!!")})
+	en.WriteExtension(&RawExtension{Type: 55, Data: []byte("raw data!!!")})
 	en.Flush()
 
 	bts := buf.Bytes()

--- a/msgp/read_test.go
+++ b/msgp/read_test.go
@@ -683,9 +683,10 @@ func TestSkip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = rd.NextType()
+	tp, err := rd.NextType()
 	if err != io.EOF {
 		t.Errorf("expected %q; got %q", io.EOF, err)
+		t.Errorf("returned type %q", tp)
 	}
 
 }
@@ -711,7 +712,7 @@ func BenchmarkSkip(b *testing.B) {
 	en.WriteBool(true)
 
 	en.WriteString("ext")
-	en.WriteExtension(&RawExtension{55, []byte("raw data!!!")})
+	en.WriteExtension(&RawExtension{Type: 55, Data: []byte("raw data!!!")})
 	en.Flush()
 
 	bts := buf.Bytes()

--- a/msgp/size.go
+++ b/msgp/size.go
@@ -36,6 +36,10 @@ const (
 	ExtensionPrefixSize = 6
 )
 
+// TODO: remove the following, and just
+// generate the appropriate code, rather
+// than calling a function that can't be inlined.
+
 // ExtensionSize is a shim for computing the size of an extension
 func ExtensionSize(e Extension) int {
 	return ExtensionPrefixSize + e.Len()


### PR DESCRIPTION
Get constant-time type information, including encoded size. 

This provides a small speedup in lots of places, and also reduces complexity and code size.

TODO: squash, etc. JSON translation will get a bit faster.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/philhofer/msgp/48)
<!-- Reviewable:end -->
